### PR TITLE
SharedTexture and Sprite/AnimatedSprite implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/.vs
 **/.vscode
 **/.zed
+**/Folder.DotSettings.user
 
 # weird mac file
 **/.DS_Store

--- a/Source/Sprite/AnimatedSprite.cs
+++ b/Source/Sprite/AnimatedSprite.cs
@@ -1,0 +1,68 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace MagicBrosMario.Source.Sprite;
+
+/// <summary>
+/// animated sprite class that uses a <see cref="SharedTexture"/><br/>
+///
+/// this class should not be initiated outside SharedTexture
+/// </summary>
+/// <param name="texture">shared texture</param>
+/// <param name="offsetX">x offset on texture</param>
+/// <param name="offsetY">y offset on texture</param>
+/// <param name="frameWidth">width of a single frame</param>
+/// <param name="frameHeight">height of a single frame</param>
+/// <param name="frameCount">number of frame</param>
+/// <param name="secPerFrame">time each frame is on the screen</param>
+public class AnimatedSprite(
+    SharedTexture texture,
+    int offsetX,
+    int offsetY,
+    int frameWidth,
+    int frameHeight,
+    int frameCount,
+    float secPerFrame
+) : ISprite
+{
+    public bool IsAnimated => true;
+
+    public int X { get; set; }
+
+    public int Y { get; set; }
+
+    public Rectangle DestRect { get; private set; }
+
+    public float Scale
+    {
+        get;
+        set
+        {
+            // update field and destination rectangle
+            field = value;
+            DestRect = new Rectangle(X, Y, (int)(value * frameWidth), (int)(value * frameHeight));
+        }
+    } = 1;
+
+    private int frame = 0;
+    private float timer = 0;
+
+    public void Update(GameTime gameTime)
+    {
+        timer += gameTime.ElapsedGameTime.Milliseconds;
+        var msPerFrame = secPerFrame * 1000f;
+
+        if (!(timer > msPerFrame)) return;
+
+        // update current frame
+        var framePassed = (int)(timer / msPerFrame);
+        frame = (frame + framePassed) % frameCount;
+        timer -= framePassed * msPerFrame;
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        var sourceRect = new Rectangle(offsetX + frameWidth * frame, offsetY, frameWidth, frameHeight);
+        spriteBatch.Draw(texture.Texture, DestRect, sourceRect, Color.White);
+    }
+}

--- a/Source/Sprite/ISprite.cs
+++ b/Source/Sprite/ISprite.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace MagicBrosMario.Source.Sprite;
+
+/// <summary>
+/// sprite interface for animated and non-animated sprite
+/// </summary>
+public interface ISprite
+{
+    /// <summary>
+    /// true for animated sprite and false for non-animated
+    /// </summary>
+    public bool IsAnimated { get; }
+
+    /// <summary>
+    /// x position of sprite
+    /// </summary>
+    public int X { get; set; }
+
+    /// <summary>
+    /// y position of sprite
+    /// </summary>
+    public int Y { get; set; }
+
+    /// <summary>
+    /// destination rectangle, contains the drawing width and height
+    /// </summary>
+    public Rectangle DestRect { get; }
+
+    /// <summary>
+    /// scale of sprite
+    /// </summary>
+    public float Scale { get; set; }
+
+    /// <summary>
+    /// update function for sprite, currently only used by AnimatedSprite
+    /// </summary>
+    /// <param name="gameTime">gameTime</param>
+    public void Update(GameTime gameTime);
+
+    /// <summary>
+    /// draw function for sprite
+    ///
+    /// there is no IsVisible and OutOfScreen check for sprite
+    /// </summary>
+    /// <param name="spriteBatch"></param>
+    public void Draw(SpriteBatch spriteBatch);
+}

--- a/Source/Sprite/SharedTexture.cs
+++ b/Source/Sprite/SharedTexture.cs
@@ -1,0 +1,94 @@
+using System;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace MagicBrosMario.Source.Sprite;
+
+/// <summary>
+/// create a shared texture
+/// <code lang="csharp">
+/// <![CDATA[
+/// var sharedTexture = new SharedTexture();
+/// 
+/// // create a new sprite from the shared texture
+/// var sprite = sharedTexture.NewSprite(100, 100, 50, 50);
+/// 
+/// // create a new animated sprite from the shared texture
+/// // with 10 frames and 2 frames per second
+/// var animatedSprite = sharedTexture.NewAnimatedSprite(
+///     100, 100, 50, 50, 10, 0.5
+/// );
+/// 
+/// /* in LoadContent */
+/// var texture = Content.Load<Texture2D>("texture_image");
+/// 
+/// // this binds the texture to both sprite, animated sprite
+/// // and any sprite that is create with the same SharedTexture
+/// sharedTexture.BindTexture(texture);
+///
+/// /* in Update */
+/// // update is required for animated texture
+/// animatedTexture.Update(gameTime);
+///
+/// // update is not required for non-animated texture
+/// sprite.Update(gameTime);
+/// 
+/// /* in Draw */
+/// sprite.Draw(spriteBatch);
+/// animatedSprite.Draw(spriteBatch);
+/// ]]></code>
+/// </summary>
+public class SharedTexture
+{
+    /// <summary>
+    /// texture of this shared texture
+    /// </summary>
+    public Texture2D Texture { get; private set; }
+
+    /// <summary>
+    /// bind a texture to this shared texture<br/>
+    ///
+    /// every sprite created with this shared texture will be linked to <paramref name="texture"/>
+    /// </summary>
+    /// <param name="texture">texture to bind</param>
+    /// <exception cref="Exception">thrown when texture is bound twice</exception>
+    public void BindTexture(Texture2D texture)
+    {
+        if (Texture != null)
+        {
+            throw new Exception("overriding shared texture is not allowed");
+        }
+
+        Texture = texture;
+    }
+
+    /// <summary>
+    /// create a new non-animated sprite from this shared texture
+    /// </summary>
+    /// <param name="offsetX">x offset on texture</param>
+    /// <param name="offsetY">y offset on texture</param>
+    /// <param name="width">width of sprite</param>
+    /// <param name="height">height of sprite</param>
+    /// <returns>a new non-animated sprite using this shared texture</returns>
+    public Sprite NewSprite(int offsetX, int offsetY, int width, int height)
+    {
+        return new Sprite(this, offsetX, offsetY, width, height);
+    }
+
+    /// <summary>
+    /// create a new animated sprite from this shared texture
+    /// </summary>
+    /// <param name="offsetX">x offset on texture</param>
+    /// <param name="offsetY">y offset on texture</param>
+    /// <param name="width">width of a single frame</param>
+    /// <param name="height">height of a single frame</param>
+    /// <param name="frameCount">number of frame</param>
+    /// <param name="secPerFrame">time each frame is on the screen</param>
+    /// <returns>a new animated sprite using this shared texture</returns>
+    public AnimatedSprite NewAnimatedSprite(
+        int offsetX, int offsetY,
+        int width, int height,
+        int frameCount, float secPerFrame)
+    {
+        return new AnimatedSprite(this, offsetX, offsetY, width, height, frameCount, secPerFrame);
+    }
+}

--- a/Source/Sprite/Sprite.cs
+++ b/Source/Sprite/Sprite.cs
@@ -1,0 +1,54 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace MagicBrosMario.Source.Sprite;
+
+/// <summary>
+/// non-animated sprite class that uses a <see cref="SharedTexture"/><br/>
+///
+/// this class should not be initiated outside SharedTexture
+/// </summary>
+/// <param name="texture">shared texture</param>
+/// <param name="offsetX">x offset on texture</param>
+/// <param name="offsetY">y offset on texture</param>
+/// <param name="width">width of sprite</param>
+/// <param name="height">height of sprite</param>
+public class Sprite(
+    SharedTexture texture,
+    int offsetX,
+    int offsetY,
+    int width,
+    int height
+) : ISprite
+{
+    public bool IsAnimated => false;
+
+    public int X { get; set; }
+
+    public int Y { get; set; }
+
+    public Rectangle DestRect { get; private set; }
+
+    public float Scale
+    {
+        get;
+        set
+        {
+            // update field and destination rectangle
+            field = value;
+            DestRect = new Rectangle(X, Y, (int)(value * width), (int)(value * height));
+        }
+    } = 1;
+
+    private readonly Rectangle sourceRect = new(offsetX, offsetY, width, height);
+
+    public void Update(GameTime gameTime)
+    {
+        // no update for non-animated sprite
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        spriteBatch.Draw(texture.Texture, sourceRect, DestRect, Color.White);
+    }
+}


### PR DESCRIPTION
## Add sprite system with shared texture support

Created `SharedTexture`, allowing multiple sprites to reference a single `Texture2D` that can be intialized later during content loading(after Sprite has been created).

### Changes

- **`ISprite`** – Common interface for sprites exposing position, scale, destination rectangle, and `Update`/`Draw` methods.
- **`SharedTexture`** – Holds a `Texture2D` reference that can be bound once and shared across all sprites created from it. Provides factory methods `NewSprite` and `NewAnimatedSprite`.
- **`AnimatedSprite`** – Implements frame-based animation using a horizontal strip on the texture atlas, advancing frames based on elapsed time.

### Design notes

- `SharedTexture.BindTexture` enforces single-bind semantics to prevent accidental texture replacement at runtime.
- Animation timing accumulates elapsed milliseconds and handles frame skipping if a large delta occurs.

### Example

```csharp
var sharedTexture = new SharedTexture();

// create a new sprite from the shared texture
var sprite = sharedTexture.NewSprite(100, 100, 50, 50);

// create a new animated sprite from the shared texture
// with 10 frames and 2 frames per second
var animatedSprite = sharedTexture.NewAnimatedSprite(
    100, 100, 50, 50, 10, 0.5
);

/* in LoadContent */
var texture = Content.Load<Texture2D>("texture_image");

// this binds the texture to both sprite, animated sprite
// and any sprite that is create with the same SharedTexture
sharedTexture.BindTexture(texture);

/* in Update */
// update is required for animated texture
animatedTexture.Update(gameTime);

// update is not required for non-animated texture
sprite.Update(gameTime);

/* in Draw */
sprite.Draw(spriteBatch);
animatedSprite.Draw(spriteBatch);```